### PR TITLE
Update fixtures with quoted fonts

### DIFF
--- a/test/fixtures/config/output.css
+++ b/test/fixtures/config/output.css
@@ -1,5 +1,5 @@
 html {
-    font: 125%/1.5em EB Garamond,sans-serif;
+    font: 125%/1.5em 'EB Garamond','sans-serif';
     box-sizing: border-box;
     overflow-y: scroll;
 }
@@ -14,7 +14,7 @@ html {
 }
 body {
     color: hsla(0,0%,0%,0.8);
-    font-family: EB Garamond,sans-serif;
+    font-family: 'EB Garamond','sans-serif';
     font-weight: 400;
     word-wrap: break-word;
     font-kerning: normal;
@@ -44,7 +44,7 @@ h1 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 2rem;
@@ -60,7 +60,7 @@ h2 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 1.51572rem;
@@ -76,7 +76,7 @@ h3 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 1.31951rem;
@@ -92,7 +92,7 @@ h4 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 1rem;
@@ -108,7 +108,7 @@ h5 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 0.87055rem;
@@ -124,7 +124,7 @@ h6 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: Open Sans,sans-serif;
+    font-family: 'Open Sans','sans-serif';
     font-weight: 400;
     text-rendering: optimizeLegibility;
     font-size: 0.81225rem;

--- a/test/fixtures/overrides/output.css
+++ b/test/fixtures/overrides/output.css
@@ -1,5 +1,5 @@
 html {
-    font: 100%/1.5em georgia,serif;
+    font: 100%/1.5em 'georgia','serif';
     box-sizing: border-box;
     overflow-y: scroll;
 }
@@ -14,7 +14,7 @@ html {
 }
 body {
     color: hsla(0,0%,0%,0.8);
-    font-family: georgia,serif;
+    font-family: 'georgia','serif';
     font-weight: normal;
     word-wrap: break-word;
     font-kerning: normal;
@@ -44,7 +44,7 @@ h1 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 2rem;
@@ -60,7 +60,7 @@ h2 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1.51572rem;
@@ -76,7 +76,7 @@ h3 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1.31951rem;
@@ -92,7 +92,7 @@ h4 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1rem;
@@ -108,7 +108,7 @@ h5 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 0.87055rem;
@@ -124,7 +124,7 @@ h6 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 0.81225rem;

--- a/test/fixtures/test/output.css
+++ b/test/fixtures/test/output.css
@@ -1,5 +1,5 @@
 html {
-    font: 100%/1.5em georgia,serif;
+    font: 100%/1.5em 'georgia','serif';
     box-sizing: border-box;
     overflow-y: scroll;
 }
@@ -14,7 +14,7 @@ html {
 }
 body {
     color: hsla(0,0%,0%,0.8);
-    font-family: georgia,serif;
+    font-family: 'georgia','serif';
     font-weight: normal;
     word-wrap: break-word;
     font-kerning: normal;
@@ -44,7 +44,7 @@ h1 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 2rem;
@@ -60,7 +60,7 @@ h2 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1.51572rem;
@@ -76,7 +76,7 @@ h3 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1.31951rem;
@@ -92,7 +92,7 @@ h4 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 1rem;
@@ -108,7 +108,7 @@ h5 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 0.87055rem;
@@ -124,7 +124,7 @@ h6 {
     padding-top: 0;
     margin-bottom: 1.5rem;
     color: inherit;
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    font-family: '-apple-system','BlinkMacSystemFont','Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue','sans-serif';
     font-weight: bold;
     text-rendering: optimizeLegibility;
     font-size: 0.81225rem;


### PR DESCRIPTION
Hi,

I looked into why the tests have been failing recently and it looks like it's because the output now puts quotes around the font family names. I was wary about putting quotes around the built-in ones like `serif` and `sans-serif`, but I did some browser testing and it seems to work.

This ought to get the tests passing again so the Greenkeeper PRs can go through.

Thanks for this helpful library!